### PR TITLE
add authorization provider

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import {ThemeProvider} from "styled-components";
 import {wrapper} from "stores";
 import {GlobalStyle} from "styles/GlobalStyle";
 import {themes} from "styles/theme";
+import {AuthorizationProvider} from "utils/authorization";
 import {UserProvider} from "utils/user";
 import "utils/firebase"; 
 
@@ -13,7 +14,9 @@ function MyApp({Component, pageProps: {session, ...pageProps}}: AppProps) {
       <UserProvider>
         <ThemeProvider theme={themes.dark}>
           <GlobalStyle />
-          <Component {...pageProps} />
+          <AuthorizationProvider>
+            <Component {...pageProps} />
+          </AuthorizationProvider>
         </ThemeProvider>
       </UserProvider>
     </SessionProvider>

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -13,14 +13,14 @@ import {LayoutCenter} from "components/layout-center";
 export default function SignIn({
   providers,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const {data: session} = useSession();
+  const {status} = useSession();
   const router = useRouter();
 
   useEffect(() => {
-    if (session) {
-      router.push("/");
+    if (status === "authenticated") {
+      router.replace("/");
     }
-  }, [session, router]);
+  }, [router, status]);
 
   return (
     <LayoutCenter>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import {Book as BookOpen,BookHalf} from "@styled-icons/bootstrap";
 import {Book as BookClose,BookDead} from "@styled-icons/fa-solid";
 import {Menu} from "@styled-icons/feather";
 import type {NextPage} from "next";
-import {signIn, useSession} from "next-auth/react";
 import React, {useCallback, useState,useEffect} from "react"
 import * as S from "./index.styled";
 import {Calendar} from "components/calendar"
@@ -19,15 +18,6 @@ export type UserInfo = {
 }
 
 const Home: NextPage = () => {
-  const {data: session} = useSession();
-
-  useEffect(() => {
-    if (!session) {
-      signIn();
-    }
-    if(session) console.log(session.user?.name,session.user?.email);
-  }, [session]);
-
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [userInfo, setUserInfo] = useState({
     name : "HongBeen Lee",
@@ -48,7 +38,7 @@ const Home: NextPage = () => {
     }
   },[isMenuOpen]);
 
-  return !session ? null : (
+  return (
     <LayoutMain>
       <S.IconList>
         <S.MenuIcon onClick={handleOpenMenu}>

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -5,10 +5,15 @@ import {LayoutNavigation} from "components/layout-navigation";
 import {useDataSaga, DataActionType, DataSagaStatus} from "stores/data";
 
 const TestPage: NextPage = () => {
+  const {data: loggedInUserData} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
   const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS)
   const {fetch: createTaskFetch, data: createTaskData, status: createTaskStatus} = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK)
   const {fetch: deleteTaskFetch, status: deleteTaskStatus} = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK)
 
+  useEffect(()=>{
+    console.log("loggedInUserData: ", loggedInUserData); // TODO: remove 
+  },[loggedInUserData])
+  
   useEffect(()=>{
     getTasksByDaysFetch({
       startDay: new Date("1999-11-11"),

--- a/utils/authorization.tsx
+++ b/utils/authorization.tsx
@@ -1,0 +1,40 @@
+import {useSession} from "next-auth/react"
+import {useRouter} from "next/router"
+import React, {ReactNode, useEffect, useMemo} from "react"
+import {LayoutCenter} from "components/layout-center"
+
+type AuthorizationProviderProps = {
+  children: ReactNode
+}
+
+const PUBLIC_PAGE_PATHNAMES = ["/auth/signin"]
+
+export const AuthorizationProvider = ({
+  children
+}: AuthorizationProviderProps) => {
+  const router = useRouter();
+  const {status} = useSession()
+  
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      const SIGN_IN_PATHNAME = "/auth/signin"
+      if (router.pathname !== SIGN_IN_PATHNAME){
+        router.push(SIGN_IN_PATHNAME);
+      }
+    }
+  }, [router, status]);
+
+  const isPublicPage = useMemo(()=>{
+    return PUBLIC_PAGE_PATHNAMES.some(item=>{
+      return router.pathname.includes(item)
+    })
+  },[router.pathname])
+
+  return (<>{
+    status === "loading" 
+      ?  <LayoutCenter>{"loading"}</LayoutCenter>
+      : (status === "unauthenticated") && !isPublicPage 
+        ? <LayoutCenter>{"unauthenticated"}</LayoutCenter>
+        : children
+  }</>)
+}

--- a/utils/user.tsx
+++ b/utils/user.tsx
@@ -14,7 +14,7 @@ export const UserProvider = ({
   const dispatch = useDispatch()
   const {data: session, status} = useSession()
   const {fetch} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
-  
+
   const sessionUserId = ((session?.user || {}) as any).id as string
 
   useEffect(()=>{
@@ -44,7 +44,5 @@ export const UserProvider = ({
     }
   },[fetch, session?.user?.email, session?.user?.image, session?.user?.name, sessionUserId, status])
 
-  return (<>
-    {children}
-  </>)
+  return (<>{children}</>)
 }


### PR DESCRIPTION
### /utils/authorization.tsx 
- 여기서 현재 로그인 여부에 따라 페이지 내용을 다르게 표시해줍니다
  - 즉, 로그인 안하면 일반 페이지들을 볼 수 없고, 로그인 페이지로 이동합니다
  - 추후에 로딩 화면을 넣어야 겠네요
 
### /pages/test/index.tsx
- 여기서 로그인한 유저 정보 읽는 예시 추가했습니다, 각 페이지에서 참고하면 될듯해요
- /utils/user.tsx 에서 서버에 유저 정보를  요청하는 작업을 해주기때문에 각 페이지에서 서버에 데이터를 요청하는 작업(fetch)을 안해도 되는 거에요