### PR TITLE
Feat/user delete saga

### DIFF
--- a/pages/test/user/index.tsx
+++ b/pages/test/user/index.tsx
@@ -37,10 +37,13 @@ const TestUserPage: NextPage = () => {
       pathSegments: [loggedInUserId],
     })
     
+  },[loggedInUserId, deleteUserFetch])
+
+  useEffect(()=>{
     if(deleteUserStatus===DataSagaStatus.SUCCEEDED){
       signOut({callbackUrl: "/"});
     }
-  },[loggedInUserId, deleteUserFetch,deleteUserStatus])
+  },[deleteUserStatus])
 
   const handleLeftButtonClick = useCallback(()=>{
   },[])

--- a/pages/test/user/index.tsx
+++ b/pages/test/user/index.tsx
@@ -1,8 +1,11 @@
-import {LayoutNavigation} from "components/layout-navigation";
 import type {NextPage} from "next"
+import {useSession} from "next-auth/react"
+import {signOut} from "next-auth/react"
+import {useRouter} from "next/router";
 import React, {useCallback, useEffect} from "react"
 import {useSelector} from "react-redux";
 import * as S from "./index.styled";
+import {LayoutNavigation} from "components/templates/layout-navigation";
 import {useDataSaga, DataActionType, DataSagaStatus} from "stores/data";
 import {RootState} from "stores/reducers";
 
@@ -14,6 +17,7 @@ const TestUserPage: NextPage = () => {
     getLoggedInUserDataRefetch()
   },[getLoggedInUserDataRefetch])
   const {fetch: updateUserFetch, status: updateUserStatus} = useDataSaga<DataActionType.UPDATE_USER>(DataActionType.UPDATE_USER, {onSucceed})
+  const {fetch: deleteUserFetch, status: deleteUserStatus} = useDataSaga<DataActionType.DELETE_USER>(DataActionType.DELETE_USER)
 
   const handleUpdate = useCallback(()=>{
     if (!loggedInUserId) return;
@@ -26,6 +30,18 @@ const TestUserPage: NextPage = () => {
     })
   },[loggedInUserId, updateUserFetch])
 
+  const handleDelete = useCallback(()=>{
+    if (!loggedInUserId) return;
+
+    deleteUserFetch({
+      pathSegments: [loggedInUserId],
+    })
+    
+    if(deleteUserStatus===DataSagaStatus.SUCCEEDED){
+      signOut({callbackUrl: "/"});
+    }
+  },[loggedInUserId, deleteUserFetch,deleteUserStatus])
+
   const handleLeftButtonClick = useCallback(()=>{
   },[])
 
@@ -35,7 +51,8 @@ const TestUserPage: NextPage = () => {
       title="test goals"
       onLeftButtonClick={handleLeftButtonClick}
     >
-      <S.Button onClick={handleUpdate}>UPDATE</S.Button>
+      <S.Button onClick={handleUpdate}>UPDATE NAME</S.Button>
+      <S.Button onClick={handleDelete}>DELETE</S.Button>
 
       <div>
         <div>{loggedInUserData?.name}</div>

--- a/stores/data/actions.ts
+++ b/stores/data/actions.ts
@@ -16,6 +16,7 @@ export enum DataActionType {
   CREATE_GOAL = "data/CREATE_GOAL",
   UPDATE_GOAL = "data/UPDATE_GOAL",
   DELETE_GOAL = "data/DELETE_GOAL",
+  DELETE_USER = "data/DELETE_USER"
 }
 
 export type DataSagaActionType = (
@@ -28,7 +29,8 @@ export type DataSagaActionType = (
   DataActionType.GET_GOALS |
   DataActionType.CREATE_GOAL |
   DataActionType.UPDATE_GOAL |
-  DataActionType.DELETE_GOAL
+  DataActionType.DELETE_GOAL |
+  DataActionType.DELETE_USER
 )
 
 export enum Authority {
@@ -47,6 +49,7 @@ export const dataSagaAuthority:Record<DataSagaActionType, Authority> = {
   [DataActionType.CREATE_GOAL]: Authority.AUTHOR,
   [DataActionType.UPDATE_GOAL]: Authority.AUTHOR,
   [DataActionType.DELETE_GOAL]: Authority.AUTHOR,
+  [DataActionType.DELETE_USER]: Authority.AUTHOR,
 }
 
 export type DataActionPayload = {
@@ -100,6 +103,9 @@ export type DataActionPayload = {
   [DataActionType.DELETE_GOAL]: SagaDataActionDefaultPayload & 
     Omit<DeleteDocumentArguments, "path"> & {
     }
+  [DataActionType.DELETE_USER]: SagaDataActionDefaultPayload & 
+  Omit<DeleteDocumentArguments, "path"> & {
+    }
 }
 
 export type SagaDataActionDefaultPayload = {
@@ -122,6 +128,7 @@ export const dataActionCreators = {
   [DataActionType.CREATE_GOAL]: (payload: DataActionPayload[DataActionType.CREATE_GOAL]) => ({type: DataActionType.CREATE_GOAL, payload}),
   [DataActionType.UPDATE_GOAL]: (payload: DataActionPayload[DataActionType.UPDATE_GOAL]) => ({type: DataActionType.UPDATE_GOAL, payload}),
   [DataActionType.DELETE_GOAL]: (payload: DataActionPayload[DataActionType.DELETE_GOAL]) => ({type: DataActionType.DELETE_GOAL, payload}),
+  [DataActionType.DELETE_USER]: (payload: DataActionPayload[DataActionType.DELETE_USER]) => ({type: DataActionType.DELETE_USER, payload}),
 }
 
 export type DataActionInstance<DataActionTypeT extends DataActionType> = ReturnType<typeof dataActionCreators[DataActionTypeT]>

--- a/stores/data/reducers.ts
+++ b/stores/data/reducers.ts
@@ -13,6 +13,7 @@ export type State = {
   [DataActionType.CREATE_GOAL]: Record<string, DataSagaState & {data: GoalData | undefined, payload:DataActionPayload[DataActionType.CREATE_GOAL]}>,
   [DataActionType.UPDATE_GOAL]: Record<string, DataSagaState & {data: GoalData | undefined, payload:DataActionPayload[DataActionType.UPDATE_GOAL]}>,
   [DataActionType.DELETE_GOAL]: Record<string, DataSagaState & {data: undefined, payload:DataActionPayload[DataActionType.DELETE_GOAL]}>,
+  [DataActionType.DELETE_USER]: Record<string, DataSagaState & {data: undefined, payload:DataActionPayload[DataActionType.DELETE_USER]}>,
 }
 
 const initialState: State = {
@@ -26,6 +27,7 @@ const initialState: State = {
   [DataActionType.CREATE_GOAL]: {},
   [DataActionType.UPDATE_GOAL]: {},
   [DataActionType.DELETE_GOAL]: {},
+  [DataActionType.DELETE_USER]: {},
 };
 
 export const dataReducer = handleActions<State, any>(

--- a/stores/data/sagas/deleteUser.ts
+++ b/stores/data/sagas/deleteUser.ts
@@ -1,0 +1,52 @@
+import {call, getContext, put} from "redux-saga/effects";
+import {dataActionCreators, DataActionInstance, DataActionType} from "../actions";
+import {DataSagaStatus} from "../types";
+import {Repository, DeleteDocumentData} from "utils/firebase";
+
+export function* deleteUser(
+  action:DataActionInstance<DataActionType.DELETE_USER>){
+  const payload = action.payload;
+  const sagakey = payload.key;
+  const sagaDataActionType = DataActionType.DELETE_USER;
+
+  const repository: Repository = yield getContext("repository");
+
+  yield put(
+    dataActionCreators[DataActionType.SET_DATA_STATUS]({
+      type: sagaDataActionType,
+      key: sagakey,
+      status: DataSagaStatus.LOADING,
+    })
+  );
+
+  try{
+    const response: DeleteDocumentData = yield call(
+      [repository, repository.deleteDocument],
+      {
+        path: "users",
+        pathSegments: payload.pathSegments,
+      }
+    );
+
+    yield put(
+      dataActionCreators[DataActionType.SET_DATA_STATUS]({
+        type: sagaDataActionType,
+        key: sagakey,
+        status: DataSagaStatus.SUCCEEDED,
+      })
+    );
+  }catch(error){
+    console.error(error);
+
+    yield put(
+      dataActionCreators[DataActionType.SET_DATA_STATUS]({
+        type: sagaDataActionType,
+        key: sagakey,
+        status: DataSagaStatus.FAILED,
+      })
+    )
+  }
+
+
+
+}

--- a/stores/data/sagas/index.ts
+++ b/stores/data/sagas/index.ts
@@ -4,6 +4,7 @@ import {createGoal} from "./createGoal";
 import {createTask} from "./createTask";
 import {deleteGoal} from "./deleteGoal";
 import {deleteTask} from "./deleteTask"
+import {deleteUser} from "./deleteUser"
 import {getGoals} from "./getGoals";
 import {getLoggedInUserData} from "./getLoggedInUserData"
 import {getTasksByDays} from "./getTasksByDays"
@@ -22,4 +23,5 @@ export function* dataSaga() {
   yield takeEvery(DataActionType.CREATE_GOAL, createGoal)
   yield takeEvery(DataActionType.UPDATE_GOAL, updateGoal)
   yield takeEvery(DataActionType.DELETE_GOAL, deleteGoal)
+  yield takeEvery(DataActionType.DELETE_USER, deleteUser)
 }


### PR DESCRIPTION
유저 탈퇴하는 사가를 만들었습니다.
use case는 test/user페이지에서 delete버튼에 연결된 함수를 보시면 됩니다~

1. test/user 페이지에서 delete버튼을 누른다.
2. 현재 로그인 되어있는 id가 파이어베이스 데이터에서 삭제된다.
3. 성공적으로 삭제되었다면 next.js에서 세션을 삭제하고 메인페이지(URL: `"/"`)로 돌아간다.

![QuickTime movie](https://user-images.githubusercontent.com/65804460/159155193-6b310ec0-fafd-4b53-9f91-0c95bc8e1875.gif)

+) 재현님코드를 거의 따라쳐서 약간 얹혀가는 느낌이.. 하하 갓재현님