### PR TITLE
fix hydrate merge option

### DIFF
--- a/pages/test/ssr/index.tsx
+++ b/pages/test/ssr/index.tsx
@@ -1,5 +1,6 @@
 import type {NextPage} from "next"
-import React, {useMemo} from "react"
+import {useRouter} from "next/router";
+import React, {useEffect, useMemo} from "react"
 import {LayoutNavigation} from "components/templates/layout-navigation";
 import {wrapper} from "stores";
 import {useDataSaga, DataActionType,TaskData,GoalData, dataActionCreators, DataSagaStatus} from "stores/data";
@@ -7,9 +8,14 @@ import {waitDuringLoading} from "stores/data/ssr";
 import * as S from "styles/pages/test/feed-public.styled";
 
 const TestSsrPage: NextPage = ({}) => {
+  const router = useRouter()
   const {data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
   const {data: getGoalsByIdsData} = useDataSaga<DataActionType.GET_GOALS_BY_IDS>(DataActionType.GET_GOALS_BY_IDS)
 
+  useEffect(()=>{
+    console.log("getPublicTasksData: ", getPublicTasksData?.length); // TODO: remove 
+  },[getPublicTasksData])
+  
   const publicTasksAndGoals = useMemo(()=>{
     if(!getPublicTasksData || !getGoalsByIdsData) return;
 
@@ -26,6 +32,7 @@ const TestSsrPage: NextPage = ({}) => {
 
   return (
     <LayoutNavigation>
+      <div onClick={()=>router.push("/test/user")}>go to test/user</div>
       <S.ListTask>
         {(publicTasksAndGoals || []).map(item => (
           <S.ListItemTask key={item.task.id}>

--- a/pages/test/user/index.tsx
+++ b/pages/test/user/index.tsx
@@ -1,5 +1,4 @@
 import type {NextPage} from "next"
-import {useSession} from "next-auth/react"
 import {signOut} from "next-auth/react"
 import {useRouter} from "next/router";
 import React, {useCallback, useEffect} from "react"
@@ -10,6 +9,7 @@ import {RootState} from "stores/reducers";
 import * as S from "styles/pages/test/user.styled";
 
 const TestUserPage: NextPage = () => {
+  const router = useRouter();
   const loggedInUserId = useSelector((state: RootState)=>state.navigation.loggedInUserId)
   const {data: loggedInUserData, refetch: getLoggedInUserDataRefetch} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
 
@@ -47,6 +47,7 @@ const TestUserPage: NextPage = () => {
 
   return (
     <LayoutNavigation>
+      <div onClick={()=>router.push("/test/ssr")}>go to test/ssr</div>
       <S.Button onClick={handleUpdate}>UPDATE NAME</S.Button>
       <S.Button onClick={handleDelete}>DELETE</S.Button>
 

--- a/stores/reducers.ts
+++ b/stores/reducers.ts
@@ -1,4 +1,4 @@
-import merge from "deepmerge"
+import merge, {Options as MergeOptions} from "deepmerge"
 import {HYDRATE} from "next-redux-wrapper";
 import {combineReducers} from "redux";
 import {dataReducer, State as DataState, initialState as dataInitialState} from "./data";
@@ -19,12 +19,29 @@ const initialRootState: RootState = {
   navigation: navigationInitialState
 }
 
+const combineMerge: MergeOptions["arrayMerge"] = (previousArray, incomingArray, options) => {
+  const resultArray: typeof previousArray = [...previousArray]
+
+  incomingArray.forEach((incomingItem) => {
+    const prevItemIndex = previousArray.findIndex(previousItem => previousItem.id)
+    if (prevItemIndex !== -1){
+      resultArray[prevItemIndex] = merge(resultArray[prevItemIndex], incomingItem, options)
+    }
+    else {
+      resultArray.push(incomingItem)
+    }
+  })
+  return resultArray
+}
+
 const rootReducer = (state = initialRootState, action: any) => {
   if (action.type === HYDRATE) {
-    const incomingState = action.payload as RootState
+    const incomingServerSideState = action.payload as RootState
 
-    const nextState: RootState = merge(state, incomingState)
-
+    const nextState: RootState = {
+      navigation: state.navigation,
+      data: merge(state.data, incomingServerSideState.data, {arrayMerge: combineMerge})
+    }
     return nextState;
   } else {
     return combinedReducer(state, action);

--- a/stores/reducers.ts
+++ b/stores/reducers.ts
@@ -19,7 +19,7 @@ const initialRootState: RootState = {
   navigation: navigationInitialState
 }
 
-const combineMerge: MergeOptions["arrayMerge"] = (previousArray, incomingArray, options) => {
+const arrayMerge: MergeOptions["arrayMerge"] = (previousArray, incomingArray, options) => {
   const resultArray: typeof previousArray = [...previousArray]
 
   incomingArray.forEach((incomingItem) => {
@@ -34,17 +34,17 @@ const combineMerge: MergeOptions["arrayMerge"] = (previousArray, incomingArray, 
   return resultArray
 }
 
-const rootReducer = (state = initialRootState, action: any) => {
+const rootReducer = (previousClientState = initialRootState, action: any) => {
   if (action.type === HYDRATE) {
-    const incomingServerSideState = action.payload as RootState
+    const incomingServerState = action.payload as RootState
 
     const nextState: RootState = {
-      navigation: state.navigation,
-      data: merge(state.data, incomingServerSideState.data, {arrayMerge: combineMerge})
+      navigation: previousClientState.navigation,
+      data: merge(previousClientState.data, incomingServerState.data, {arrayMerge})
     }
     return nextState;
   } else {
-    return combinedReducer(state, action);
+    return combinedReducer(previousClientState, action);
   }
 };
 

--- a/stores/reducers.ts
+++ b/stores/reducers.ts
@@ -23,7 +23,7 @@ const arrayMerge: MergeOptions["arrayMerge"] = (previousArray, incomingArray, op
   const resultArray: typeof previousArray = [...previousArray]
 
   incomingArray.forEach((incomingItem) => {
-    const prevItemIndex = previousArray.findIndex(previousItem => previousItem.id)
+    const prevItemIndex = previousArray.findIndex(previousItem => previousItem.id === incomingItem.id)
     if (prevItemIndex !== -1){
       resultArray[prevItemIndex] = merge(resultArray[prevItemIndex], incomingItem, options)
     }


### PR DESCRIPTION
### 한줄 정리
hydrate 에서 클라이언트 state 와 서버사이드 state 를 가지고 최종 state 를 만들때 상황마다 다르게 작업해야 한다 
(다음 3가지 선택지 중 하나: a. merge, b. 클라이언트 state 의 부분만 이용, c. 서버사이드 state 의 부분만 이용)

### 이번 PR 수정사항
hydrate 에서
- navigation 은 항상 클라이언트 state를 반환
  - 서버사이드에서는 navigation state 는 이용하지 않도록!
- data 에서는 클라이언트 + 서버사이드 state 를 deepmerge 해서 반환 하되,
  - 배열의 경우 (예: TaskData[]) id 값으로 같은 데이터를 판단해서 똑똑하게 deepmerge 한다
    - `[{id:1}]` + `[{id: 1}, {id: 2}]` 의 결과가 `[{id: 1}, {id: 1}, {id: 2}]`가 아닌 `[{id: 1}, {id: 2}]` 가 되도록!