### PR TITLE
fix compliments fetch getTasksComplimentsMap

### DIFF
--- a/components/moleculs/feedItem/feedItem.tsx
+++ b/components/moleculs/feedItem/feedItem.tsx
@@ -13,8 +13,16 @@ type FeedItemProps = {
 }
 
 export const FeedItem = ({task, goal}: FeedItemProps) => {
-  const {status} = useSession()
-  const {fetch:createComplimentFetch} = useDataSaga<DataActionType.CREATE_COMPLIMENT>(DataActionType.CREATE_COMPLIMENT)
+  const {status} = useSession()  
+  const {fetch:getPublicTasksFetch} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
+  const onSucceed = useCallback(()=>{
+    getPublicTasksFetch({
+      startTime: new Date("1999-11-11"),
+      endTime: new Date("2222-11-11"),
+    })
+  },[getPublicTasksFetch])
+
+  const {fetch:createComplimentFetch} = useDataSaga<DataActionType.CREATE_COMPLIMENT>(DataActionType.CREATE_COMPLIMENT, {additionalKeys: [task.id],onSucceed})
   const [isClicked, setIsClicked] = useState(false);
   const [clickedEmoji, setClickedEmoji] = useState<ComplimentData["type"]>("red-heart");
 

--- a/pages/test/ssr/index.tsx
+++ b/pages/test/ssr/index.tsx
@@ -12,10 +12,6 @@ const TestSsrPage: NextPage = ({}) => {
   const {data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
   const {data: getGoalsByIdsData} = useDataSaga<DataActionType.GET_GOALS_BY_IDS>(DataActionType.GET_GOALS_BY_IDS)
 
-  useEffect(()=>{
-    console.log("getPublicTasksData: ", getPublicTasksData?.length); // TODO: remove 
-  },[getPublicTasksData])
-  
   const publicTasksAndGoals = useMemo(()=>{
     if(!getPublicTasksData || !getGoalsByIdsData) return;
 
@@ -62,10 +58,7 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async ({re
 
   const tasksGoal = store.getState().data[DataActionType.GET_PUBLIC_TASKS][GET_PUBLIC_TASKS_KEY].data?.map(item => item.goal)
 
-  console.log("tasksGoal: ", tasksGoal?.length); // TODO: remove
-
   const goals = Array.from(new Set(tasksGoal))
-  console.log("goals: ", goals); // TODO: remove
 
   const goalGroups = []
   while (goals.length > 0){
@@ -83,7 +76,6 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async ({re
   await waitDuringLoading(store, {actionType: DataActionType.GET_GOALS_BY_IDS, key: GET_GOALS_BY_IDS_KEY})
 
   const fetchedGoals = store.getState().data[DataActionType.GET_GOALS_BY_IDS][GET_GOALS_BY_IDS_KEY].data?.length
-  console.log("fetchedGoals: ", fetchedGoals); // TODO: remove
 
   return ({
     props: {}

--- a/pages/test/tasks/index.tsx
+++ b/pages/test/tasks/index.tsx
@@ -13,10 +13,6 @@ const TestTasksPage: NextPage = () => {
   const {fetch: deleteTaskFetch, status: deleteTaskStatus} = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK)
 
   useEffect(()=>{
-    console.log("loggedInUserData: ", loggedInUserData); // TODO: remove 
-  },[loggedInUserData])
-
-  useEffect(()=>{
     getTasksByDaysFetch({
       startDay: new Date("1999-11-11"),
       endDay: new Date("2222-11-11"),

--- a/stores/data/hooks.tsx
+++ b/stores/data/hooks.tsx
@@ -8,7 +8,7 @@ import {RootState} from "stores/reducers"
 export const useDataSaga = <DataSagaActionTypeT extends DataSagaActionType>(
   actionType: DataSagaActionType,
   options: {
-    additionalKeys?: (keyof DataActionPayload[DataSagaActionTypeT])[]
+    additionalKeys?: string[]
     onSucceed?: (data?: RootState["data"][DataSagaActionTypeT][string]["data"]) => void
     onFail?: () => void
   } = {}

--- a/stores/data/sagas/utils/index.ts
+++ b/stores/data/sagas/utils/index.ts
@@ -12,7 +12,7 @@ export const getTasksComplimentsMap = async ({
   const map = new Map<string, ComplimentData[]>()
 
   try {
-    tasks.forEach(async (task)=>{
+    await Promise.all(tasks.map(async (task)=>{
       const queryConstraints: QueryConstraint[] = []
       queryConstraints.push(where("task", "==", task))
 
@@ -27,7 +27,7 @@ export const getTasksComplimentsMap = async ({
       }))
 
       map.set(task, complimentData)
-    })
+    }))
 
     return map
   }


### PR DESCRIPTION
- 각 task 에 대한 compliments fetch 할때 await 안써서 return 이 일찍되던 이슈 해결
- createCompliment 의 onSucceed 에 getPublicTasks 추가!
  - 이때 additional keys 이용 필요 (없으면 한번 createCompliment 할때 모든 태스크의 feedItem 에서 getPublicTasks 실행된다)