### PR TITLE
add make key params required

### DIFF
--- a/components/moleculs/feedItem/feedItem.tsx
+++ b/components/moleculs/feedItem/feedItem.tsx
@@ -18,15 +18,15 @@ type FeedItemProps = {
 export const FeedItem = ({task, goal}: FeedItemProps) => {
   const loggedInUserId = useSelector((state:RootState)=>state.navigation.loggedInUserId)
   const {status} = useSession()  
-  const {fetch:getPublicTasksFetch} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
+  const {fetch:getPublicTasksFetch} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS, [])
   const onSucceed = useCallback(()=>{
     getPublicTasksFetch({
       startTime: new Date("1999-11-11"),
       endTime: new Date("2222-11-11"),
     })
   },[getPublicTasksFetch])
-  const {fetch:createComplimentFetch} = useDataSaga<DataActionType.CREATE_COMPLIMENT>(DataActionType.CREATE_COMPLIMENT, {additionalKeys: [task._id],onSucceed})
-  const {fetch: deleteComplimentFetch} = useDataSaga<DataActionType.DELETE_COMPLIMENT>(DataActionType.DELETE_COMPLIMENT,{onSucceed})
+  const {fetch: createComplimentFetch} = useDataSaga<DataActionType.CREATE_COMPLIMENT>(DataActionType.CREATE_COMPLIMENT, [task._id], {onSucceed})
+  const {fetch: deleteComplimentFetch} = useDataSaga<DataActionType.DELETE_COMPLIMENT>(DataActionType.DELETE_COMPLIMENT, [task._id], {onSucceed})
 
   const [isClicked, setIsClicked] = useState(false);
   const [clickedEmoji, setClickedEmoji] = useState<ComplimentData["type"]>("red-heart");
@@ -35,12 +35,11 @@ export const FeedItem = ({task, goal}: FeedItemProps) => {
     return task.compliments.find(compliment => compliment.author === loggedInUserId);
   },[loggedInUserId,task.compliments])
 
-
   const handleDelete = useCallback(()=>{
     if(!complimented) return;
 
     deleteComplimentFetch({
-      id: complimented._id
+      id: complimented._id,
     })
   },[deleteComplimentFetch,complimented])
 

--- a/components/organisms/goals/goals.tsx
+++ b/components/organisms/goals/goals.tsx
@@ -11,7 +11,7 @@ export const Goals = () => {
   const loggedInUserId = useSelector((state:RootState)=>state.navigation.loggedInUserId)
 
   const {fetch: getGoalsFetch, data: getGoalsData} =
-    useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS);
+    useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS, []);
 
   useEffect(() => {
     if (!loggedInUserId) return;

--- a/components/organisms/sidebarSetting/sidebarSetting.tsx
+++ b/components/organisms/sidebarSetting/sidebarSetting.tsx
@@ -17,11 +17,11 @@ export const SidebarSetting = ({
 }:SidebarSettingProps) => {
   const {
     data: loggedInUserData,
-  } = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA);
+  } = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, []);
   const {
     fetch: getGoalsFetch,
     data: getGoalsData,
-  } = useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS);
+  } = useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS, []);
   
   const goals = useMemo(() => {
     return (getGoalsData?.goals || []).sort((a, b) => a.createdAt - b.createdAt);

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -41,30 +41,30 @@ const Feed: NextPage = () => {
   const {
     data: loggedInUserData,
     status: loggedInUserStatus
-  } = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA);
+  } = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, []);
   const {
     fetch: getTasksByDaysFetch,
     status: getTasksByDaysStatus,
     data: getTasksByDaysData,
     refetch: getTasksByDaysRefetch,
-  } = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS);
+  } = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS, []);
   const {
     fetch: createTaskFetch, 
     status: createTaskStatus
-  } = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK);
+  } = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK, []);
   const {
     fetch: deleteTaskFetch, 
     status: deleteTaskStatus
-  } = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK);
+  } = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK, []);
   const {
     fetch: updateTaskFetch, 
     status: updateTaskStatus
-  } = useDataSaga<DataActionType.UPDATE_TASK>(DataActionType.UPDATE_TASK);
+  } = useDataSaga<DataActionType.UPDATE_TASK>(DataActionType.UPDATE_TASK, []);
   const {
     fetch: getGoalsFetch, 
     data: getGoalsData,
     status: getGoalssStatus
-  } = useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS);
+  } = useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS, []);
   const pageAuthorId = useSelector(
     (state: RootState) => state.navigation.pageAuthorId
   );

--- a/pages/goals/form/index.tsx
+++ b/pages/goals/form/index.tsx
@@ -14,15 +14,18 @@ import {RootState} from "stores/reducers";
 const GoalsFormPage: NextPage = () => {
   const loggedInUserId = useSelector((state:RootState)=>state.navigation.loggedInUserId)
   const {fetch: getGoalsFetch, data: goals} =
-    useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS);
+    useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS, []);
   const {fetch: createGoalFetch} = useDataSaga<DataActionType.CREATE_GOAL>(
-    DataActionType.CREATE_GOAL
+    DataActionType.CREATE_GOAL,
+    []
   );
   const {fetch: updateGoalFetch} = useDataSaga<DataActionType.UPDATE_GOAL>(
-    DataActionType.UPDATE_GOAL
+    DataActionType.UPDATE_GOAL,
+    []
   );
   const {fetch: deleteGoalFetch} = useDataSaga<DataActionType.DELETE_GOAL>(
-    DataActionType.DELETE_GOAL
+    DataActionType.DELETE_GOAL,
+    []
   );
 
   const [goal, setGoal] = useState<GoalData>();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,7 @@ import {LayoutMain} from "components/templates/layout-main"
 import {useDataSaga, DataActionType} from "stores/data";
 
 const Home: NextPage = () => {
-  const {fetch: getPublicTasksFetch, data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
+  const {fetch: getPublicTasksFetch, data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS, [])
   const router = useRouter();
 
   useEffect(()=>{

--- a/pages/setting/index.tsx
+++ b/pages/setting/index.tsx
@@ -15,18 +15,19 @@ const SettingPage: NextPage = () => {
   );
   const {data: loggedInUserData, refetch: getLoggedInUserDataRefetch} =
     useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(
-      DataActionType.GET_LOGGED_IN_USER_DATA
+      DataActionType.GET_LOGGED_IN_USER_DATA,
+      []
     );
 
   const onSucceed = useCallback(() => {
     getLoggedInUserDataRefetch();
   }, [getLoggedInUserDataRefetch]);
   const {fetch: updateUserFetch, status: updateUserStatus} =
-    useDataSaga<DataActionType.UPDATE_USER>(DataActionType.UPDATE_USER, {
-      onSucceed,
+    useDataSaga<DataActionType.UPDATE_USER>(DataActionType.UPDATE_USER, [], {
+      onSucceed
     });
   const {fetch: deleteUserFetch, status: deleteUserStatus} =
-    useDataSaga<DataActionType.DELETE_USER>(DataActionType.DELETE_USER);
+    useDataSaga<DataActionType.DELETE_USER>(DataActionType.DELETE_USER, []);
 
   const handleUpdate = useCallback(
     (name: string) => {

--- a/pages/test/compliments/index.tsx
+++ b/pages/test/compliments/index.tsx
@@ -12,16 +12,16 @@ const TestTasksPage: NextPage = () => {
 
   const [createdComplimentId, setCreatedComplimentId] = useState<string | undefined>()
 
-  const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS)
+  const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS, [])
   
   const onCreateSucceed = useCallback((data?: ComplimentData | null)=>{
     setCreatedComplimentId(data?._id)
   },[])
 
-  const {fetch: createComplimentFetch} = useDataSaga<DataActionType.CREATE_COMPLIMENT>(DataActionType.CREATE_COMPLIMENT, {
+  const {fetch: createComplimentFetch} = useDataSaga<DataActionType.CREATE_COMPLIMENT>(DataActionType.CREATE_COMPLIMENT, [], {
     onSucceed: onCreateSucceed
   })
-  const {fetch: deleteComplimentFetch} = useDataSaga<DataActionType.DELETE_COMPLIMENT>(DataActionType.DELETE_COMPLIMENT)
+  const {fetch: deleteComplimentFetch} = useDataSaga<DataActionType.DELETE_COMPLIMENT>(DataActionType.DELETE_COMPLIMENT, [])
 
   useEffect(()=>{
     getTasksByDaysFetch({

--- a/pages/test/feed-public/index.tsx
+++ b/pages/test/feed-public/index.tsx
@@ -6,8 +6,8 @@ import {useDataSaga, DataActionType} from "stores/data";
 import * as S from "styles/pages/test/feed-public.styled";
 
 const TestFeedPublicPage: NextPage = () => {
-  const {fetch: getPublicTasksFetch, data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
-  const {fetch: getGoalsByIdsFetch, data: getGoalsByIdsData} = useDataSaga<DataActionType.GET_GOALS_BY_IDS>(DataActionType.GET_GOALS_BY_IDS)
+  const {fetch: getPublicTasksFetch, data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS, [])
+  const {fetch: getGoalsByIdsFetch, data: getGoalsByIdsData} = useDataSaga<DataActionType.GET_GOALS_BY_IDS>(DataActionType.GET_GOALS_BY_IDS, [])
 
   const taskGoalIdList = useMemo(()=>{
     const taskGoalIdList:Set<string> = new Set(getPublicTasksData?.tasks?.map(item => item.goal));

--- a/pages/test/goals/index.tsx
+++ b/pages/test/goals/index.tsx
@@ -8,15 +8,15 @@ import * as S from "styles/pages/test/goals.styled";
 
 const TestGoalsPage: NextPage = () => {
   const loggedInUserId = useSelector((state:RootState)=>state.navigation.loggedInUserId)
-  const {fetch: getGoalsFetch, data: getGoalsData, refetch: getGoalsRefetch} = useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS)
+  const {fetch: getGoalsFetch, data: getGoalsData, refetch: getGoalsRefetch} = useDataSaga<DataActionType.GET_GOALS>(DataActionType.GET_GOALS, [])
 
   const onSucceed = useCallback(()=>{
     getGoalsRefetch()
   },[getGoalsRefetch])
 
-  const {fetch: createGoalFetch} = useDataSaga<DataActionType.CREATE_GOAL>(DataActionType.CREATE_GOAL, {onSucceed: ()=>getGoalsRefetch()})
-  const {fetch: updateGoalFetch} = useDataSaga<DataActionType.UPDATE_GOAL>(DataActionType.UPDATE_GOAL, {onSucceed})
-  const {fetch: deleteGoalFetch} = useDataSaga<DataActionType.DELETE_GOAL>(DataActionType.DELETE_GOAL, {onSucceed})
+  const {fetch: createGoalFetch} = useDataSaga<DataActionType.CREATE_GOAL>(DataActionType.CREATE_GOAL, [], {onSucceed: ()=>getGoalsRefetch()})
+  const {fetch: updateGoalFetch} = useDataSaga<DataActionType.UPDATE_GOAL>(DataActionType.UPDATE_GOAL, [], {onSucceed})
+  const {fetch: deleteGoalFetch} = useDataSaga<DataActionType.DELETE_GOAL>(DataActionType.DELETE_GOAL, [], {onSucceed})
 
   useEffect(()=>{
     if (!loggedInUserId) return;

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -5,10 +5,10 @@ import {useDataSaga, DataActionType, DataSagaStatus} from "stores/data";
 import * as S from "styles/pages/test.styled";
 
 const TestPage: NextPage = () => {
-  const {data: loggedInUserData} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
-  const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS)
-  const {fetch: createTaskFetch, data: createTaskData, status: createTaskStatus} = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK)
-  const {fetch: deleteTaskFetch, status: deleteTaskStatus} = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK)
+  const {data: loggedInUserData} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, [])
+  const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS, [])
+  const {fetch: createTaskFetch, data: createTaskData, status: createTaskStatus} = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK, [])
+  const {fetch: deleteTaskFetch, status: deleteTaskStatus} = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK, [])
 
   useEffect(()=>{
     getTasksByDaysFetch({

--- a/pages/test/ssr/index.tsx
+++ b/pages/test/ssr/index.tsx
@@ -10,8 +10,8 @@ import * as S from "styles/pages/test/feed-public.styled";
 
 const TestSsrPage: NextPage = ({}) => {
   const router = useRouter()
-  const {data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS)
-  const {data: getGoalsByIdsData} = useDataSaga<DataActionType.GET_GOALS_BY_IDS>(DataActionType.GET_GOALS_BY_IDS)
+  const {data: getPublicTasksData} = useDataSaga<DataActionType.GET_PUBLIC_TASKS>(DataActionType.GET_PUBLIC_TASKS, [])
+  const {data: getGoalsByIdsData} = useDataSaga<DataActionType.GET_GOALS_BY_IDS>(DataActionType.GET_GOALS_BY_IDS, [])
 
   const publicTasksAndGoals = useMemo(()=>{
     if(!getPublicTasksData || !getGoalsByIdsData) return;

--- a/pages/test/tasks/index.tsx
+++ b/pages/test/tasks/index.tsx
@@ -5,12 +5,12 @@ import {useDataSaga, DataActionType, DataSagaStatus} from "stores/data";
 import * as S from "styles/pages/test/tasks.styled";
 
 const TestTasksPage: NextPage = () => {
-  const {data: loggedInUserData} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
-  const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS)
+  const {data: loggedInUserData} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, [])
+  const {fetch: getTasksByDaysFetch, data: getTasksByDaysData, refetch: getTasksByDaysRefetch} = useDataSaga<DataActionType.GET_TASKS_BY_DAYS>(DataActionType.GET_TASKS_BY_DAYS, [])
   
-  const {fetch: createTaskFetch, status: createTaskStatus} = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK)
-  const {fetch: updateTaskFetch, status: updateTaskStatus} = useDataSaga<DataActionType.UPDATE_TASK>(DataActionType.UPDATE_TASK)
-  const {fetch: deleteTaskFetch, status: deleteTaskStatus} = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK)
+  const {fetch: createTaskFetch, status: createTaskStatus} = useDataSaga<DataActionType.CREATE_TASK>(DataActionType.CREATE_TASK, [])
+  const {fetch: updateTaskFetch, status: updateTaskStatus} = useDataSaga<DataActionType.UPDATE_TASK>(DataActionType.UPDATE_TASK, [])
+  const {fetch: deleteTaskFetch, status: deleteTaskStatus} = useDataSaga<DataActionType.DELETE_TASK>(DataActionType.DELETE_TASK, [])
 
   useEffect(()=>{
     getTasksByDaysFetch({

--- a/pages/test/user/index.tsx
+++ b/pages/test/user/index.tsx
@@ -11,13 +11,13 @@ import * as S from "styles/pages/test/user.styled";
 const TestUserPage: NextPage = () => {
   const router = useRouter();
   const loggedInUserId = useSelector((state: RootState)=>state.navigation.loggedInUserId)
-  const {data: loggedInUserData, refetch: getLoggedInUserDataRefetch} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
+  const {data: loggedInUserData, refetch: getLoggedInUserDataRefetch} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, [])
 
   const onSucceed = useCallback(()=>{
     getLoggedInUserDataRefetch()
   },[getLoggedInUserDataRefetch])
-  const {fetch: updateUserFetch, status: updateUserStatus} = useDataSaga<DataActionType.UPDATE_USER>(DataActionType.UPDATE_USER, {onSucceed})
-  const {fetch: deleteUserFetch, status: deleteUserStatus} = useDataSaga<DataActionType.DELETE_USER>(DataActionType.DELETE_USER)
+  const {fetch: updateUserFetch, status: updateUserStatus} = useDataSaga<DataActionType.UPDATE_USER>(DataActionType.UPDATE_USER, [], {onSucceed})
+  const {fetch: deleteUserFetch, status: deleteUserStatus} = useDataSaga<DataActionType.DELETE_USER>(DataActionType.DELETE_USER, [])
 
   const handleUpdate = useCallback(()=>{
     if (!loggedInUserId) return;

--- a/stores/data/hooks.tsx
+++ b/stores/data/hooks.tsx
@@ -7,14 +7,14 @@ import {RootState} from "stores/reducers"
 
 export const useDataSaga = <DataSagaActionTypeT extends DataSagaActionType>(
   actionType: DataSagaActionType,
+  keys: string[],
   options: {
-    additionalKeys?: string[]
     onSucceed?: (data?: RootState["data"][DataSagaActionTypeT][string]["data"]) => void
     onFail?: () => void
   } = {}
 ) => { 
   const dispatch = useDispatch()
-  const {additionalKeys, onSucceed, onFail} = options
+  const {onSucceed, onFail} = options
 
   // pageAuthorId
   const pageAuthorId = useSelector((state:RootState)=>state.navigation.pageAuthorId)
@@ -42,8 +42,8 @@ export const useDataSaga = <DataSagaActionTypeT extends DataSagaActionType>(
 
   // key
   const key = useMemo(()=>{
-    return [defaultFetchAuthor || "", ...(additionalKeys || [])].sort().join()
-  },[additionalKeys, defaultFetchAuthor])
+    return [defaultFetchAuthor || "", ...(keys || [])].sort().join()
+  },[keys, defaultFetchAuthor])
 
   const keyRef = useRef<typeof key>(key)
   useEffect(()=>{

--- a/utils/authentication.tsx
+++ b/utils/authentication.tsx
@@ -18,7 +18,7 @@ export const AuthenticationProvider = ({
 }: AuthenticationProviderProps) => {
   const dispatch = useDispatch()
   const {data: session, status} = useSession()
-  const {fetch, data} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
+  const {fetch, data} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, [])
 
   const sessionUserId = getSessionUserId(session)
 

--- a/utils/authorization.tsx
+++ b/utils/authorization.tsx
@@ -20,7 +20,7 @@ export const AuthorizationProvider = ({
   const router = useRouter();
   const {status, data: session} = useSession()
   const dispatch = useDispatch()
-  const {data} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA)
+  const {data} = useDataSaga<DataActionType.GET_LOGGED_IN_USER_DATA>(DataActionType.GET_LOGGED_IN_USER_DATA, [])
 
   useEffect(() => {
     if (status === "unauthenticated") {


### PR DESCRIPTION
useDataSaga 에서 `keys` 를 필수로 전달하도록 수정했습니다.

`keys` 는 useDataSaga 에서 해당 쿼리를 다른 쿼리와 구분하는 `key` 를 생성하는데 쓰입니다.

### 예1
 `DataActionType.CREATE_TASK` 를 여러 곳에서 쓸 때, keys를 전달하지 않으면 동일한 요청으로 취급됩니다. 따라서 동일하지 않은 요청을 구분하기 위해서 keys 전달이 필요합니다.
 
 ### 예2
 `DataActionType.GET_LOGGED_IN_USER_DATA` 등 쿼리를 여러번하지 않고 데이터만 접근할때 keys 를 지정하지 않습니다